### PR TITLE
remove useless constructors in Jest mocks to fix lint warnings

### DIFF
--- a/ediky_front/src/setupTests.js
+++ b/ediky_front/src/setupTests.js
@@ -1,46 +1,33 @@
 // ediky_frontend/src/setupTests.js
 
-// 1) Add jest-dom matchers:
 import '@testing-library/jest-dom';
 
-// 2) Polyfill TextEncoder/TextDecoder for Undici in Firebase Auth:
+// Polyfills
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
-
-// 3) Polyfill ReadableStream for Undici in Firebase Auth:
 if (typeof global.ReadableStream === 'undefined') {
   global.ReadableStream = require('stream/web').ReadableStream;
 }
 
-// 4) Mock all Firebase modules so Jest never tries to load undici or real Firebase code:
-jest.mock('firebase/app', () => {
-  return {
-    initializeApp: jest.fn(() => ({})),
-  };
-});
-jest.mock('firebase/auth', () => {
-  return {
-    getAuth: jest.fn(() => ({})),
-  };
-});
-jest.mock('firebase/firestore', () => {
-  return {
-    getFirestore: jest.fn(() => ({})),
-  };
+// Firebase mocks
+jest.mock('firebase/app', () => ({ initializeApp: jest.fn(() => ({})) }));
+jest.mock('firebase/auth', () => ({ getAuth: jest.fn(() => ({})) }));
+jest.mock('firebase/firestore', () => ({ getFirestore: jest.fn(() => ({})) }));
+
+// ogl mock – no useless constructors
+jest.mock('ogl', () => {
+  class Renderer {}
+  class Camera {}
+  class Transform {}
+  return { Renderer, Camera, Transform };
 });
 
-// 5) Mock “ogl” so Jest doesn’t parse its ESM:
-jest.mock('ogl', () => ({
-  Renderer: class { constructor() {} },
-  Camera: class { constructor() {} },
-  Transform: class { constructor() {} },
-}));
-
-// 6) Mock the Three.js example that uses ESM syntax:
+// Three.js RoomEnvironment mock – no useless constructor
 jest.mock(
   'three/examples/jsm/environments/RoomEnvironment.js',
-  () => ({
-    RoomEnvironment: class { constructor() {} },
-  }),
+  () => {
+    class RoomEnvironment {}
+    return { RoomEnvironment };
+  },
   { virtual: true }
 );


### PR DESCRIPTION
## Summary

Removes empty constructors from Jest mock classes in `ediky_front/src/setupTests.js` to resolve ESLint `no-useless-constructor` warnings during CI. This keeps the test setup clean and avoids unnecessary lint noise.

Closes: #79 
## Type

* [x] Bug fix
* [ ] Feature
* [x] Refactor / Cleanup
* [ ] Docs
* [ ] CI/Build

## Changes

* Removed empty `constructor() {}` methods from mock classes (`Renderer`, `Camera`, `Transform`, `RoomEnvironment`).
* Updated mocks to use simple class definitions without constructors.
* Verified tests still pass with updated mocks.

## Screenshots / Demos (if UI)

*N/A – no UI changes.*

## How to Test

1. Pull this branch and install dependencies:

   ```bash
   npm install
   ```
2. Run lint:

   ```bash
   npm run lint
   ```

   **Expected:** No `no-useless-constructor` warnings.
3. Run tests:

   ```bash
   npm test
   ```

   **Expected:** All tests pass.

## Breaking Changes

* [x] None

## Checklist

* [x] I ran locally and verified behavior
* [x] Added/updated tests (N/A – no logic changes)
* [x] Linked related issues (`Fixes #<issue_number>`)
* [x] Followed coding style and lint rules
* [x] No large unrelated diffs (formatting, reorg)